### PR TITLE
Add m4_ifdef(AM_PATH_GPGME) else branch

### DIFF
--- a/src/build/configure.ac
+++ b/src/build/configure.ac
@@ -1111,7 +1111,8 @@ AC_ARG_ENABLE(  [gpgme-linking],
                                 ],
                                 [ AC_MSG_WARN([Public key support (GPGME linking) requires version greater than $gpgme_min_version]) ]
                                )
-                        ])
+                        ],
+                        [AC_MSG_WARN([AM_PATH_GPGME macro not found!])])
                  else
                     AC_MSG_WARN([Public key support (GPGME linking) requires libgcrypt (strong encryption support)])
                  fi


### PR DESCRIPTION
Hi Denis,

It seems like, at least autoconf-2.69 needs an else branch for the m4_ifdef macro to work.
Otherwise asymetrical encryption support could not be enabled for me.

Best regards,
Tobias